### PR TITLE
Update appServices.js

### DIFF
--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -261,7 +261,7 @@ export function startApiServer() {
 // 停止 API 服务器
 export function stopApiServer() {
     if (apiProcess) {
-        kill(apiProcess.pid);
+        process.kill(apiProcess.pid, 'SIGKILL');
         apiProcess = null;
     }
 }


### PR DESCRIPTION
解决了linux下软件退出无法关闭api-linux的情况，已测试win平台不会出现兼容性错误（也就是退出软件不会关闭api）