### PR TITLE
修复 linux 右键点击托盘无效

### DIFF
--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -187,9 +187,17 @@ export function createTray(mainWindow) {
     ]);
 
     tray.setToolTip('MoeKoe Music');
-    tray.on('right-click', () => {
-        tray.popUpContextMenu(contextMenu);
-    });
+
+    switch (process.platform) {
+        case 'linux':
+            tray.setContextMenu(contextMenu);
+            break;
+        default:
+            tray.on('right-click', () => {
+                tray.popUpContextMenu(contextMenu);
+            });
+            return;
+    }
     tray.on('click', () => {
         mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show();
     });


### PR DESCRIPTION
#170 

![image](https://github.com/user-attachments/assets/1bc2822e-182a-48b2-b315-a76c72042532)

原来的写法只支持 win 和 mac ，新增写法支持 linux，但是

![image](https://github.com/user-attachments/assets/04a84132-720b-432f-bb84-c0c17cb770e8)

这种写法会导致 mac 方法失效，所以对 linux 单独处理 



测试环境

![image](https://github.com/user-attachments/assets/002a26b2-fee2-48c4-becd-7e43d45078ef)


