### PR TITLE
feat: 支持原生的窗口装饰器

### DIFF
--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -17,6 +17,8 @@ let tray = null;
 
 // 创建主窗口
 export function createWindow() {
+    const savedConfig = store.get('settings');
+    const useNativeTitleBar = savedConfig?.nativeTitleBar === 'on' ? true : false;
     const { width: screenWidth, height: screenHeight } = screen.getPrimaryDisplay().workAreaSize;
 
     const windowWidth = Math.min(1200, screenWidth * 0.8);
@@ -29,8 +31,8 @@ export function createWindow() {
         y: lastWindowState.y || Math.floor((screenHeight - windowHeight) / 2),
         minWidth: 890,
         minHeight: 750,
-        frame: false,
-        titleBarStyle: 'hiddenInset',
+        frame: useNativeTitleBar,
+        titleBarStyle: useNativeTitleBar ? 'default' : 'hiddenInset',
         autoHideMenuBar: true,
         webPreferences: {
             preload: path.join(__dirname, 'preload.cjs'),
@@ -84,7 +86,6 @@ export function createWindow() {
         setThumbarButtons(mainWindow);
     }
 
-    const savedConfig = store.get('settings');
     if (savedConfig?.desktopLyrics === 'on') {
         createLyricsWindow();
     }
@@ -120,7 +121,7 @@ export function createLyricsWindow() {
             nodeIntegration: false,
             sandbox: false,
             webSecurity: true,
-            backgroundThrottling: false, 
+            backgroundThrottling: false,
             zoomFactor: 1.0
         }
     });
@@ -178,49 +179,49 @@ export function createTray(mainWindow, title='') {
 
     const contextMenu = Menu.buildFromTemplate([
         {
-            label: '项目主页', 
+            label: '项目主页',
             icon: isDev ? path.join(__dirname, '../build/icons/menu/home.png') : path.join(process.resourcesPath, 'icons', 'menu', 'home.png'),
             click: () => {
                 shell.openExternal('https://github.com/iAJue/');
             }
         },
         {
-            label: '反馈bug', 
+            label: '反馈bug',
             icon: isDev ? path.join(__dirname, '../build/icons/menu/bug.png') : path.join(process.resourcesPath, 'icons', 'menu', 'bug.png'),
             click: () => {
                 shell.openExternal('https://github.com/iAJue/MoeKoeMusic/issues');
             }
         },
         {
-            label: '上一首', 
-            icon: isDev ? path.join(__dirname, '../build/icons/menu/prev.png') : path.join(process.resourcesPath, 'icons', 'menu', 'prev.png'), accelerator: 'Alt+CommandOrControl+Left', 
+            label: '上一首',
+            icon: isDev ? path.join(__dirname, '../build/icons/menu/prev.png') : path.join(process.resourcesPath, 'icons', 'menu', 'prev.png'), accelerator: 'Alt+CommandOrControl+Left',
             click: () => {
                 mainWindow.webContents.send('play-previous-track');
             }
         },
         {
-            label: '暂停', accelerator: 'Alt+CommandOrControl+Space', 
+            label: '暂停', accelerator: 'Alt+CommandOrControl+Space',
             icon: isDev ? path.join(__dirname, '../build/icons/menu/play.png') : path.join(process.resourcesPath, 'icons', 'menu', 'play.png'),
             click: () => {
                 mainWindow.webContents.send('toggle-play-pause');
             }
         },
         {
-            label: '下一首', accelerator: 'Alt+CommandOrControl+Right', 
+            label: '下一首', accelerator: 'Alt+CommandOrControl+Right',
             icon: isDev ? path.join(__dirname, '../build/icons/menu/next.png') : path.join(process.resourcesPath, 'icons', 'menu', 'next.png'),
             click: () => {
                 mainWindow.webContents.send('play-next-track');
             }
         },
         {
-            label: '检查更新', 
+            label: '检查更新',
             icon: isDev ? path.join(__dirname, '../build/icons/menu/update.png') : path.join(process.resourcesPath, 'icons', 'menu', 'update.png'),
             click: () => {
                 checkForUpdates(false);
             }
         },
         {
-            label: '显示/隐藏', accelerator: 'CmdOrCtrl+Shift+S', 
+            label: '显示/隐藏', accelerator: 'CmdOrCtrl+Shift+S',
             icon: isDev ? path.join(__dirname, '../build/icons/menu/show.png') : path.join(process.resourcesPath, 'icons', 'menu', 'show.png'),
             click: () => {
                 if (mainWindow) {
@@ -233,7 +234,7 @@ export function createTray(mainWindow, title='') {
             }
         },
         {
-            label: '退出程序', accelerator: 'CmdOrCtrl+Q', 
+            label: '退出程序', accelerator: 'CmdOrCtrl+Q',
             icon: isDev ? path.join(__dirname, '../build/icons/menu/quit.png') : path.join(process.resourcesPath, 'icons', 'menu', 'quit.png'),
             click: () => {
                 app.isQuitting = true;
@@ -488,7 +489,7 @@ export function setThumbarButtons(mainWindow, isPlaying = false) {
     const buttons = [
         {
             tooltip: '上一首',
-            icon: isDev 
+            icon: isDev
                 ? path.join(__dirname, '../build/icons/prev.png')
                 : path.join(process.resourcesPath, 'icons', 'prev.png'),
             click: () => {
@@ -498,7 +499,7 @@ export function setThumbarButtons(mainWindow, isPlaying = false) {
         },
         {
             tooltip: '暂停',
-            icon: isDev 
+            icon: isDev
                 ? path.join(__dirname, '../build/icons/pause.png')
                 : path.join(process.resourcesPath, 'icons', 'pause.png'),
             click: () => {
@@ -508,7 +509,7 @@ export function setThumbarButtons(mainWindow, isPlaying = false) {
         },
         {
             tooltip: '下一首',
-            icon: isDev 
+            icon: isDev
                 ? path.join(__dirname, '../build/icons/next.png')
                 : path.join(process.resourcesPath, 'icons', 'next.png'),
             click: () => {
@@ -521,7 +522,7 @@ export function setThumbarButtons(mainWindow, isPlaying = false) {
     if (!isPlaying) {
         buttons[1] = {
             tooltip: '播放',
-            icon: isDev 
+            icon: isDev
                 ? path.join(__dirname, '../build/icons/play.png')
                 : path.join(process.resourcesPath, 'icons', 'play.png'),
             click: () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,27 @@
 <template>
     <div id="app">
-        <TitleBar v-if="!isLyricsRoute" />
+        <TitleBar v-if="showTitleBar && !isLyricsRoute" />
         <RouterView />
         <Disclaimer v-if="!isLyricsRoute" />
     </div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import Disclaimer from '@/components/Disclaimer.vue';
 import TitleBar from '@/components/TitleBar.vue';
 
 const route = useRoute();
 const isLyricsRoute = computed(() => route.path === '/lyrics');
+
+// 动态控制 TitleBar 的显示
+const showTitleBar = ref(true);
+
+onMounted(() => {
+    const settings = JSON.parse(localStorage.getItem('settings')) || {};
+    showTitleBar.value = settings.nativeTitleBar !== 'on'; // 如果值为 'on'，则不显示 TitleBar
+});
 </script>
 
 <style scoped>

--- a/src/language/en.json
+++ b/src/language/en.json
@@ -19,6 +19,7 @@
   "sheng-yin": "sound",
   "tou-ding-lv": "mint green",
   "wai-guan": "Appearance",
+  "native-title-bar":"Use native window decoration",
   "xian-shi-ge-ci-bei-jing": "Show full screen lyrics background cover",
   "xian-shi-zhuo-mian-ge-ci": "Show desktop lyrics",
   "xiao": "Small",

--- a/src/language/ja.json
+++ b/src/language/ja.json
@@ -19,6 +19,7 @@
   "sheng-yin": "音",
   "tou-ding-lv": "ミントグリーン",
   "wai-guan": "外観",
+  "native-title-bar":"ネイティブタイトルバー",
   "xian-shi-ge-ci-bei-jing": "フルスクリーンの歌詞の背景カバーを表示します",
   "xian-shi-zhuo-mian-ge-ci": "デスクトップの歌詞を表示する",
   "xiao": "小さい",

--- a/src/language/ko.json
+++ b/src/language/ko.json
@@ -19,6 +19,7 @@
   "sheng-yin": "소리",
   "tou-ding-lv": "민트 그린",
   "wai-guan": "모습",
+  "native-title-bar":"네이티브 타이틀 바",
   "xian-shi-ge-ci-bei-jing": "전체 스크린 가사 배경 표지 표시",
   "xian-shi-zhuo-mian-ge-ci": "데스크톱 가사 표시",
   "xiao": "작은",

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -6,6 +6,7 @@
   "yu-yan": "语言",
   "zhu-se-tiao": "主色调",
   "wai-guan": "外观",
+  "native-title-bar":"使用原生窗口装饰器",
   "sheng-yin": "声音",
   "yin-zhi-xuan-ze": "音质选择",
   "qi-dong-wen-hou-yu": "启动问候语",

--- a/src/language/zh-TW.json
+++ b/src/language/zh-TW.json
@@ -19,6 +19,7 @@
   "sheng-yin": "聲音",
   "tou-ding-lv": "薄荷綠",
   "wai-guan": "外觀",
+  "native-title-bar":"使用原生窗口装饰器",
   "xian-shi-ge-ci-bei-jing": "顯示全屏歌詞背景封面",
   "xian-shi-zhuo-mian-ge-ci": "顯示桌面歌詞",
   "xiao": "小",

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -2,10 +2,10 @@
     <div class="settings-page">
         <section v-for="(section, sectionIndex) in settingSections" :key="sectionIndex" class="setting-section">
             <h3>{{ section.title }}</h3>
-            <div v-for="(item, itemIndex) in section.items" :key="itemIndex" 
+            <div v-for="(item, itemIndex) in section.items" :key="itemIndex"
                  class="setting-item" @click="item.action ? item.action() : openSelection(item.key)">
                 <span>{{ item.label }}
-                    <span v-if="item.showRefreshHint && showRefreshHint[item.key]" class="refresh-hint"> 
+                    <span v-if="item.showRefreshHint && showRefreshHint[item.key]" class="refresh-hint">
                         {{ item.refreshHintText }}
                     </span>
                 </span>
@@ -23,7 +23,7 @@
                         {{ option.displayText }}
                     </li>
                 </ul>
-                
+
                 <div v-if="selectionType === 'quality'" class="compatibility-option">
                     <label>
                         <input type="checkbox" v-model="qualityCompatibilityMode" />
@@ -31,16 +31,16 @@
                         <div class="compatibility-hint">如果高音质播放失败，请开启此选项</div>
                     </label>
                 </div>
-                
+
                 <div v-if="selectionType === 'highDpi'" class="scale-slider-container">
                     <div class="scale-slider-label">缩放因子: {{ dpiScale }} <span class="scale-slider-hint">调整后需要重启应用生效</span></div>
                     <div class="scale-slider-wrapper">
-                        <input 
-                            type="range" 
-                            min="0.5" 
-                            max="2" 
-                            step="0.1" 
-                            v-model="dpiScale" 
+                        <input
+                            type="range"
+                            min="0.5"
+                            max="2"
+                            step="0.1"
+                            v-model="dpiScale"
                             class="scale-slider"
                         />
                         <div class="scale-marks">
@@ -51,7 +51,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div v-if="selectionType === 'apiMode' && selectedSettings.apiMode.value === 'on'" class="api-settings-container">
                     <div class="api-setting-item">
                         <label>API 地址</label>
@@ -76,12 +76,12 @@
                 <div class="shortcut-list">
                     <div class="shortcut-item" v-for="(config, key) in shortcutConfigs" :key="key">
                         <span>{{ config.label }}</span>
-                        <div class="shortcut-input" 
-                             @click="startRecording(key)" 
+                        <div class="shortcut-input"
+                             @click="startRecording(key)"
                              :class="{ 'recording': recordingKey === key }">
                             {{ shortcuts[key] || '点击设置快捷键' }}
-                            <div v-if="shortcuts[key]" 
-                                 class="clear-shortcut" 
+                            <div v-if="shortcuts[key]"
+                                 class="clear-shortcut"
                                  @click.stop="clearShortcut(key)">
                                 ×
                             </div>
@@ -94,7 +94,7 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="reset-settings-container">
             <button @click="openResetConfirmation" class="reset-settings-button">
                 <i class="fas fa-sync-alt"></i>
@@ -124,6 +124,7 @@ const selectedSettings = ref({
     language: { displayText: '🌏 ' + t('zi-dong'), value: '' },
     themeColor: { displayText: t('shao-nv-fen'), value: 'pink' },
     theme: { displayText: '☀️ ' + t('qian-se'), value: 'light' },
+    nativeTitleBar: { displayText: t('guan-bi'), value: 'off' },
     quality: { displayText: t('pu-tong-yin-zhi'), value: 'normal' },
     lyricsBackground: { displayText: t('da-kai'), value: 'on' },
     desktopLyrics: { displayText: t('guan-bi'), value: 'off' },
@@ -156,6 +157,12 @@ const settingSections = computed(() => [
             {
                 key: 'theme',
                 label: t('wai-guan')
+            },
+            {
+                key: 'nativeTitleBar',
+                label: t('native-title-bar'),
+                showRefreshHint: true,
+                refreshHintText: t('zhong-qi-hou-sheng-xiao')
             },
             {
                 key: 'font',
@@ -269,6 +276,13 @@ const selectionTypeMap = {
             { displayText: '🌙 ' + t('shen-se'), value: 'dark' }
         ]
     },
+    nativeTitleBar: {
+        title: t('native-title-bar'),
+        options: [
+            { displayText: t('da-kai'), value: 'on' },
+            { displayText: t('guan-bi'), value: 'off' }
+        ]
+    },
     quality: {
         title: t('yin-zhi-xuan-ze'),
         options: [
@@ -363,6 +377,7 @@ const selectionTypeMap = {
 };
 
 const showRefreshHint = ref({
+    nativeTitleBar: false,
     lyricsBackground: false,
     lyricsFontSize: false,
     gpuAcceleration: false,
@@ -373,18 +388,18 @@ const showRefreshHint = ref({
 const openSelection = (type) => {
     isSelectionOpen.value = true;
     selectionType.value = type;
-    
+
     if (type === 'quality') {
         qualityCompatibilityMode.value = selectedSettings.value.qualityCompatibility?.value === 'on';
     }
-    
+
     if (type === 'highDpi') {
         dpiScale.value = parseFloat(selectedSettings.value.dpiScale?.value || '1.0');
     }
 };
 
 const selectOption = (option) => {
-    const electronFeatures = ['desktopLyrics', 'gpuAcceleration', 'minimizeToTray', 'highDpi'];
+    const electronFeatures = ['desktopLyrics', 'gpuAcceleration', 'minimizeToTray', 'highDpi', 'nativeTitleBar'];
     if (!isElectron() && electronFeatures.includes(selectionType.value)) {
         window.$modal.alert(t('fei-ke-hu-duan-huan-jing-wu-fa-qi-yong'));
         return;
@@ -393,6 +408,9 @@ const selectOption = (option) => {
     const actions = {
         'themeColor': () => proxy.$applyColorTheme(option.value),
         'theme': () => proxy.$setTheme(option.value),
+        'nativeTitleBar': () => {
+            showRefreshHint.value.nativeTitleBar = true;
+        },
         'language': () => {
             proxy.$i18n.locale = option.value;
             document.documentElement.lang = option.value;
@@ -402,13 +420,13 @@ const selectOption = (option) => {
                 window.$modal.alert(t('gao-pin-zhi-yin-le-xu-yao-deng-lu-hou-cai-neng-bo-fango'));
                 return;
             }
-            selectedSettings.value.qualityCompatibility = { 
+            selectedSettings.value.qualityCompatibility = {
                 value: qualityCompatibilityMode.value ? 'on' : 'off',
                 displayText: qualityCompatibilityMode.value ? t('kai-qi') : t('guan-bi')
             };
         },
         'highDpi': () => {
-            selectedSettings.value.dpiScale = { 
+            selectedSettings.value.dpiScale = {
                 value: dpiScale.value.toString(),
                 displayText: dpiScale.value.toString()
             };
@@ -451,9 +469,9 @@ onMounted(() => {
             if (selectionTypeMap[key] && selectionTypeMap[key].options) {
                 if (key === 'font') {
                     const value = savedSettings[key];
-                    selectedSettings.value[key] = { 
+                    selectedSettings.value[key] = {
                         displayText: value || '默认字体',
-                        value: value 
+                        value: value
                     };
                 } else {
                     const displayText = selectionTypeMap[key].options.find(
@@ -483,43 +501,43 @@ const recordingKey = ref('');
 const shortcuts = ref({});
 
 const shortcutConfigs = ref({
-    mainWindow: { 
+    mainWindow: {
         label: t('xian-shi-yin-cang-zhu-chuang-kou'),
         defaultValue: 'Ctrl+Shift+S'
     },
-    quitApp: { 
+    quitApp: {
         label: t('tui-chu-zhu-cheng-xu'),
         defaultValue: 'Ctrl+Q'
     },
-    prevTrack: { 
+    prevTrack: {
         label: t('shang-yi-shou'),
         defaultValue: 'Alt+Ctrl+Left'
     },
-    nextTrack: { 
+    nextTrack: {
         label: t('xia-yi-shou'),
         defaultValue: 'Alt+Ctrl+Right'
     },
-    playPause: { 
+    playPause: {
         label: t('zan-ting-bo-fang'),
         defaultValue: 'Alt+Ctrl+Space'
     },
-    volumeUp: { 
+    volumeUp: {
         label: t('yin-liang-zeng-jia'),
         defaultValue: 'Alt+Ctrl+Up'
     },
-    volumeDown: { 
+    volumeDown: {
         label: t('yin-liang-jian-xiao'),
         defaultValue: 'Alt+Ctrl+Down'
     },
-    mute: { 
+    mute: {
         label: t('jing-yin'),
         defaultValue: 'Alt+Ctrl+M'
     },
-    like: { 
+    like: {
         label: t('tian-jia-wo-xi-huan'),
         defaultValue: 'Alt+Ctrl+L'
     },
-    mode: { 
+    mode: {
         label: t('qie-huan-bo-fang-mo-shi'),
         defaultValue: 'Alt+Ctrl+P'
     },
@@ -546,22 +564,22 @@ const startRecording = (key) => {
 
 const recordShortcut = (e) => {
     if (!recordingKey.value) return;
-    
+
     e.preventDefault();
     const keys = [];
-    
+
     // 修饰键
     if (e.metaKey) keys.push('CommandOrControl');
     if (e.ctrlKey) keys.push('Ctrl');
     if (e.altKey) keys.push('Alt');
     if (e.shiftKey) keys.push('Shift');
-    
+
     // 如果按下了修饰键，更新提示
     if (keys.length > 0 && ['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)) {
         shortcuts.value[recordingKey.value] = keys.join('+') + t('qing-an-xia-qi-ta-jian');
         return;
     }
-    
+
     // 特殊键映射
     const specialKeys = {
         ' ': 'Space',
@@ -586,29 +604,29 @@ const recordShortcut = (e) => {
     };
 
     const key = specialKeys[e.key] || e.key.toUpperCase();
-    
+
     // 只有当按下的不是单独的修饰键时才结束记录
     if (!['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)) {
         keys.push(key);
-        
+
         if (keys.length > 0) {
             // 检查是否包含必要的修饰键
             if (!keys.some(k => ['Ctrl', 'Alt', 'Shift', 'CommandOrControl'].includes(k))) {
                 window.$modal.alert(t('kuai-jie-jian-bi-xu-bao-han-zhi-shao-yi-ge-xiu-shi-jian-ctrlaltshiftcommand'));
                 return;
             }
-            
+
             // 检查快捷键冲突
             const newShortcut = keys.join('+');
-            const conflictKey = Object.entries(shortcuts.value).find(([k, v]) => 
+            const conflictKey = Object.entries(shortcuts.value).find(([k, v]) =>
                 v === newShortcut && k !== recordingKey.value
             );
-            
+
             if (conflictKey) {
                 window.$modal.alert(t('gai-kuai-jie-jian-yu')+conflictKey[0]+t('de-kuai-jie-jian-chong-tu'));
                 return;
             }
-            
+
             shortcuts.value[recordingKey.value] = newShortcut;
             recordingKey.value = '';
             window.removeEventListener('keydown', recordShortcut);
@@ -630,15 +648,15 @@ const saveShortcuts = () => {
     }
 
     // 验证所有快捷键
-    const invalidShortcuts = Object.entries(shortcuts.value).filter(([key, value]) => 
+    const invalidShortcuts = Object.entries(shortcuts.value).filter(([key, value]) =>
         value && !validateShortcut(value)
     );
-    
+
     if (invalidShortcuts.length > 0) {
         window.$modal.alert(t('cun-zai-wu-xiao-de-kuai-jie-jian-she-zhi-qing-que-bao-mei-ge-kuai-jie-jian-du-bao-han-xiu-shi-jian'));
         return;
     }
-    
+
     try {
         let settingsToSave = JSON.parse(localStorage.getItem('settings')) || {};
         settingsToSave.shortcuts = shortcuts.value;
@@ -649,7 +667,7 @@ const saveShortcuts = () => {
         console.error('保存设置失败:', error);
         window.$modal.alert(t('bao-cun-she-zhi-shi-bai'));
     }
-    
+
     closeShortcutSettings();
 };
 


### PR DESCRIPTION
我是Linux用户，没有Windows和mac电脑，本次修改主要是对Linux桌面环境的适配，Linux不适用原生窗口管理器是没有阴影和边框的
其他环境各位大佬帮忙确认完善一下， 我前端水平一般

![image](https://github.com/user-attachments/assets/80dba941-6a75-460c-a0db-1727a40621c7)


Linux下效果如图， 开启
![image](https://github.com/user-attachments/assets/3134b3ed-44e9-4371-9406-fa320de90891)

关闭时
![image](https://github.com/user-attachments/assets/382ada2a-cf80-4f1e-b01f-938c30fe1dd5)
