### PR TITLE
ci: 添加 Docker 和 Docker Compose 配置以支持容器化部署

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Stage 1: Build Frontend
+FROM node:18-alpine AS frontend-builder
+WORKDIR /app
+COPY package*.json ./
+# Remove electron and electron-builder from package.json
+RUN node -e "const fs = require('fs'); const filePath = './package.json'; \
+             let rawdata = fs.readFileSync(filePath); let packageJson = JSON.parse(rawdata); \
+             if (packageJson.devDependencies) { \
+               delete packageJson.devDependencies.electron; \
+               delete packageJson.devDependencies['electron-builder']; \
+             } \
+             if (packageJson.dependencies) { \
+               delete packageJson.dependencies.electron; \
+             } \
+             fs.writeFileSync(filePath, JSON.stringify(packageJson, null, 2));"
+RUN npm install
+COPY . .
+RUN npm run build:docker
+
+# Stage 2: Setup Combined App
+FROM node:18-alpine
+WORKDIR /app
+
+# Install Nginx
+RUN apk add --no-cache nginx
+
+# Copy API code
+COPY ./api ./api
+# Install API dependencies
+WORKDIR /app/api
+RUN npm install --production
+# Reset WORKDIR to /app
+WORKDIR /app 
+
+# Copy built frontend static assets from the builder stage
+COPY --from=frontend-builder /app/dist/ ./dist/
+
+# Expose ports
+# For frontend served by 'serve'
+EXPOSE 8080 
+# For API
+EXPOSE 6521 
+
+# Copy Nginx configuration
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Command to run both services
+# API runs from /app/api directory, frontend served by Nginx
+CMD ["sh", "-c", "cd /app/api && node app.js & nginx -g 'daemon off;'"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,59 @@
 
 ## 📦️ 安装
 
+### 客户端安装
+
 访问本项目的 [Releases](https://github.com/iAJue/MoeKoeMusic/releases) 页面下载安装包。
+
+### WEB端安装（docker）
+
+* 注意：部署后请开放服务器对应端口才可使用，或者使用反向代理实现域名访问。
+
+> 方式一：自定义启动
+
+#### 随便创建一个目录
+
+```
+mkdir MoeKoeMusic
+```
+
+#### 进入目录
+
+```
+cd MoeKoeMusic
+```
+
+#### 下载docker-compose.yaml文件，或者手动下载放到MoeKoeMusic目录下
+
+```
+wget https://github.com/iAJue/MoeKoeMusic/blob/main/docker-compose.yml
+```
+
+> 可以根据需要修改里面的配置
+> 1.修改镜像版本号【可选】
+> 2.配置数据保存路径【可选】
+> 3.修改端口号【可选】
+
+```
+vi docker-compose.yaml # 【可选】
+```
+
+#### 启动MoeKoeMusic
+
+```
+docker compose up -d &
+```
+
+> ~~方式二：使用docker-compose一键安装 （镜像暂未上传官方）~~
+
+```
+docker run -d --name MoeKoeMusic -p 8080:8080 iajue/moekoe-music:latest
+```
+
+> 方式三：宝塔容器编排
+
+复制 https://github.com/iAJue/MoeKoeMusic/blob/main/docker-compose.yml 里面的内容，粘贴到宝塔面板的容器编排里面，点击部署即可，编排名称为MoeKoeMusic
+
 
 ## ⚙️ 开发
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.3'
+
+services:
+  moekoe-music:
+    # 镜像地址
+    image: registry.cn-wulanchabu.aliyuncs.com/youngxj/moekoe-music:latest
+    container_name: moekoe-music # 容器名
+    restart: unless-stopped # 自动重启
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports: # 端口映射
+      - "8080:8080"  # 前端服务
+      - "6521:6521"  # 接口服务

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,33 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+
+    keepalive_timeout 65;
+
+    server {
+        listen 8080;
+        server_name localhost;
+
+        location / {
+            root /app/dist;
+            index index.html;
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /api/ {
+            proxy_pass http://localhost:6521/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "install-all": "npm install && cd api && npm install",
     "serve": "vite",
     "build": "vite build",
+    "build:docker": "cross-env VITE_APP_API_URL=/api vite build",
     "preview": "vite preview",
     "electron:serve": "cross-env NODE_ENV=development electron .",
     "api": "node api/app.js",

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -5,7 +5,7 @@ import { ElMessage } from 'element-plus';
 
 // 创建一个 axios 实例
 const httpClient = axios.create({
-    baseURL: 'http://127.0.0.1:6521',
+    baseURL: import.meta.env.VITE_APP_API_URL || 'http://127.0.0.1:6521',
     timeout: 10000,
     headers: {
         'Content-Type': 'application/json',

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   base: './',
   publicPath: './',
   server: {
+    host: true,
     port: 8080, // 将开发服务器端口设置为8080，确保与其他服务兼容
   },
   resolve: {


### PR DESCRIPTION
添加 Dockerfile 和 docker-compose.yml 文件，用于构建和运行前端及 API 服务。同时更新 vite.config.js，设置开发服务器 host 为 true，以便在容器中访问
补充docker安装方式