### PR TITLE
[功能增加请求] 增加Linux-ARM64构建支持与Linux的中文构建说明更改

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ npm run build
   ```
   -	Linux:
     - ARM64架构 (aarch64)
-      
+        ```
         npm run electron:build:linux-aarch64 [AppImage 格式]
-      
+        ```
     - x86_64架构 (x64)
-      
+        ```
         npm run electron:build:linux-x64 [AppImage 格式]
-      
+        ```
       
   -	macOS: 
   ```sh

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ npm run build
   npm run electron:build:win [默认 NSIS 安装包]
   ```
   -	Linux:
-    -ARM64架构 (aarch64)
+    - ARM64架构 (aarch64)
       ```sh
       npm run electron:build:linux-aarch64 [AppImage 格式]
       ```
-    -x86_64架构 (x64)
+    - x86_64架构 (x64)
       ```sh
       npm run electron:build:linux-x64 [AppImage 格式]
       ```
@@ -174,11 +174,11 @@ npm run build
         npm run build:api:win
         ```
     - Linux:
-      -ARM64架构 (aarch64)
+      - ARM64架构 (aarch64)
             ```sh
             npm run build:api:linux-aarch64
             ```
-      -x86_64架构 (x64)
+      - x86_64架构 (x64)
             ```sh
             npm run build:api:linux-x64
             ```

--- a/README.md
+++ b/README.md
@@ -176,13 +176,11 @@ npm run build
         ```
     - Linux:
       - ARM64架构 (aarch64)
-        
             ```
             npm run build:api:linux-aarch64
             ```
         
       - x86_64架构 (x64)
-        
             ```
             npm run build:api:linux-x64
             ```

--- a/README.md
+++ b/README.md
@@ -143,14 +143,17 @@ npm run build
   npm run electron:build:win [默认 NSIS 安装包]
   ```
   -	Linux:
-    - ARM64架构 (aarch64)   
+    - ARM64架构 (aarch64)
+      
       ```
       npm run electron:build:linux-aarch64 [AppImage 格式]
       ```
-    - x86_64架构 (x64)   
+    - x86_64架构 (x64)
+      
       ```
       npm run electron:build:linux-x64 [AppImage 格式]
       ```
+      
   -	macOS: 
   ```sh
   npm run electron:build:macos [默认 macOS 双架构]
@@ -174,14 +177,18 @@ npm run build
         npm run build:api:win
         ```
     - Linux:
-      - ARM64架构 (aarch64)   
+      - ARM64架构 (aarch64)
+        
             ```
             npm run build:api:linux-aarch64
             ```
-      - x86_64架构 (x64)   
+        
+      - x86_64架构 (x64)
+        
             ```
             npm run build:api:linux-x64
             ```
+        
     - macOS:
       ```sh
       npm run build:api:macos
@@ -225,11 +232,14 @@ npm run build
    ```
 #### 3. 打包 Linux 平台
    - AppImage 格式（适用于几乎所有 Linux 发行版,NixOS等用户请自行安装运行工具）：
-     - ARM64架构 (aarch64)   
+     - ARM64架构 (aarch64)
+       
        ```
        npm run electron:build-aarch64 -- --linux
        ```
-     - x86_64架构 (x64)   
+       
+     - x86_64架构 (x64)
+       
        ```
        npm run electron:build-x64 -- --linux
        ```

--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ npm run build
   npm run electron:build:win [默认 NSIS 安装包]
   ```
   -	Linux:
-    - ARM64架构 (aarch64)
-      ```sh
+    - ARM64架构 (aarch64)   
+      ```
       npm run electron:build:linux-aarch64 [AppImage 格式]
       ```
-    - x86_64架构 (x64)
-      ```sh
+    - x86_64架构 (x64)   
+      ```
       npm run electron:build:linux-x64 [AppImage 格式]
       ```
   -	macOS: 
@@ -174,12 +174,12 @@ npm run build
         npm run build:api:win
         ```
     - Linux:
-      - ARM64架构 (aarch64)
-            ```sh
+      - ARM64架构 (aarch64)   
+            ```
             npm run build:api:linux-aarch64
             ```
-      - x86_64架构 (x64)
-            ```sh
+      - x86_64架构 (x64)   
+            ```
             npm run build:api:linux-x64
             ```
     - macOS:
@@ -225,11 +225,11 @@ npm run build
    ```
 #### 3. 打包 Linux 平台
    - AppImage 格式（适用于几乎所有 Linux 发行版,NixOS等用户请自行安装运行工具）：
-     - ARM64架构 (aarch64)
+     - ARM64架构 (aarch64)   
        ```
        npm run electron:build-aarch64 -- --linux
        ```
-     - x86_64架构 (x64)
+     - x86_64架构 (x64)   
        ```
        npm run electron:build-x64 -- --linux
        ```

--- a/README.md
+++ b/README.md
@@ -145,14 +145,12 @@ npm run build
   -	Linux:
     - ARM64架构 (aarch64)
       
-      ```
-      npm run electron:build:linux-aarch64 [AppImage 格式]
-      ```
+        npm run electron:build:linux-aarch64 [AppImage 格式]
+      
     - x86_64架构 (x64)
       
-      ```
-      npm run electron:build:linux-x64 [AppImage 格式]
-      ```
+        npm run electron:build:linux-x64 [AppImage 格式]
+      
       
   -	macOS: 
   ```sh

--- a/README.md
+++ b/README.md
@@ -142,10 +142,15 @@ npm run build
   ```sh
   npm run electron:build:win [默认 NSIS 安装包]
   ```
-  -	Linux: 
-  ```sh
-  npm run electron:build:linux [默认 AppImage 格式]
-  ```
+  -	Linux:
+    -ARM64架构 (aarch64)
+      ```sh
+      npm run electron:build:linux-aarch64 [AppImage 格式]
+      ```
+    -x86_64架构 (x64)
+      ```sh
+      npm run electron:build:linux-x64 [AppImage 格式]
+      ```
   -	macOS: 
   ```sh
   npm run electron:build:macos [默认 macOS 双架构]
@@ -169,9 +174,14 @@ npm run build
         npm run build:api:win
         ```
     - Linux:
-        ```sh
-        npm run build:api:linux
-        ```
+      -ARM64架构 (aarch64)
+            ```sh
+            npm run build:api:linux-aarch64
+            ```
+      -x86_64架构 (x64)
+            ```sh
+            npm run build:api:linux-x64
+            ```
     - macOS:
       ```sh
       npm run build:api:macos
@@ -214,22 +224,15 @@ npm run build
    npm run electron:build -- --win --portable
    ```
 #### 3. 打包 Linux 平台
-   - 默认 AppImage 格式（适用于大多数 Linux 发行版）：
-   ```
-   npm run electron:build -- --linux
-   ```
-   - snap（适用于 Ubuntu 和支持 snap 的发行版）：
-   ```
-   npm run electron:build -- --linux --target snap
-   ```
-   - 	deb（适用于 Debian/Ubuntu 系列）：
-   ```
-   npm run electron:build -- --linux --target deb
-   ```
-   - rpm（适用于 Red Hat/Fedora 系列）：
-   ```
-   npm run electron:build -- --linux --target rpm
-   ```
+   - AppImage 格式（适用于几乎所有 Linux 发行版,NixOS等用户请自行安装运行工具）：
+     - ARM64架构 (aarch64)
+       ```
+       npm run electron:build-aarch64 -- --linux
+       ```
+     - x86_64架构 (x64)
+       ```
+       npm run electron:build-x64 -- --linux
+       ```
 
 #### 4. 打包所有平台
 

--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,8 @@
     "dev": "nodemon --config nodemon.json index.js",
     "start": "node app.js",
     "pkgwin": "pkg . -t node14-win-x64 -C GZip -o bin/app_win --no-bytecode",
-    "pkglinux": "pkg . -t node14-linux-x64 -C GZip -o bin/app_linux --no-bytecode",
+    "pkglinux-x64": "pkg . -t node14-linux-x64 -C GZip -o bin/app_linux --no-bytecode",
+    "pkglinux-aarch64": "pkg . -t node14-linux-arm64 -C GZip -o bin/app_linux --no-bytecode",
     "pkgmacos": "pkg . -t node14-macos-x64 -C GZip -o bin/app_macos --no-bytecode"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -123,8 +123,7 @@
     "linux": {
       "icon": "build/icons/linux_256x256.png",
       "target": [
-        "AppImage",
-        "deb"
+        "AppImage" 
       ],
       "category": "Utility",
       "artifactName": "${productName}.${ext}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "moekoemusic",
   "version": "1.4.8",
+  "homepage": "https://github.com/iAJue/MoeKoeMusic",
   "main": "electron/main.js",
   "scripts": {
     "install-all": "npm install && cd api && npm install",
@@ -12,10 +13,12 @@
     "api": "node api/app.js",
     "dev": "npm run api & npm run serve & npm run electron:serve",
     "build:api:win": "npm run --prefix ./api pkgwin",
-    "build:api:linux": "npm run --prefix ./api pkglinux",
+    "build:api:linux-x64": "npm run --prefix ./api pkglinux-x64",
+    "build:api:linux-aarch64": "npm run --prefix ./api pkglinux-aarch64",
     "build:api:macos": "npm run --prefix ./api pkgmacos",
     "electron:build:win": "run-s build:api:win \"electron:build -- --win --publish never\"",
-    "electron:build:linux": "run-s build:api:linux \"electron:build -- --linux --publish never\"",
+    "electron:build:linux-x64": "run-s build:api:linux-x64 \"electron:build -- --linux --publish never\"",
+    "electron:build:linux-aarch64": "run-s build:api:linux-aarch64 \"electron:build -- --linux --publish never\"",
     "electron:build:macos": "run-s build:api:macos \"electron:build -- --mac --universal --publish never\"",
     "electron:build": "cross-env NODE_ENV=production electron-builder"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "owner": "iAJue",
       "repo": "MoeKoeMusic"
     },
-    "compression": "maximum",
+    "compression": "store",
     "extraResources": [
       {
         "from": "build/icons/",


### PR DESCRIPTION
经过我本人测试,MoeKoe_Music在经过api等项目的构建参数修复后,可以在ARM64设备上正常运行,我将Linux下构建说明与构建参数改为了xxx-aarch64/xxx-x64作为架构分辨,并在中文README.MD中加入了Linux下不同架构的编译说明,希望开发者可以采纳此PR以改进对Linux的ARM64架构的支持,谢谢!🌹

同时,此PR还做了以下内容,希望开发者也可以合并🌹:
1.关闭asar文件压缩,本人实测并没有很大的体积膨胀
2.关闭了Linux的RPM/DEB构建支持,有需要的可以自行基于AppImage构建,Electron应用的deb和rpm包与AppImage没有本质区别,而且构建deb的操作会在ARM64架构上报错 (我看日志貌似是Electron-builder无视架构引入了x64二进制文件导致?)
