### PR TITLE
[代码改进] 设置.gitignore不再跟踪API编译后的产物

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ dist-ssr
 test
 bin/*
 
+# Kugou API Compilation Products
+api/node_modules
+api/bin
+
 # Editor directories and files
 .codebuddy/*
 .vscode/*


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [ ] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [x] 构建/工具 (chore)
- [ ] 其他 (other):

---

将api目录下的node_modules和bin加入.gitignore, 防止代码提交时混入编译后的成品
