### PR TITLE
修复ARM64架构下Linux无法编译API而引发应用编译失败

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
     "start": "node app.js",
     "pkgwin": "pkg . -t node14-win-x64 -C GZip -o bin/app_win --no-bytecode",
     "pkglinux": "pkg . -t node14-linux-x64 -C GZip -o bin/app_linux --no-bytecode",
+    "pkglinux-aarch64": "pkg . -t node14-linux-arm64 -C GZip -o bin/app_linux --no-bytecode",
     "pkgmacos": "pkg . -t node14-macos-x64 -C GZip -o bin/app_macos --no-bytecode",
     "pkgwin_lite": "pkg . -t node14-win-x64 --options platform=lite -C GZip -o bin/app_win --no-bytecode",
     "pkgjs": "esbuild index.js --bundle --minify --outfile=bin/api_js/app.js --platform=node && mkdir -p bin/api_js/util bin/api_js/module && esbuild util/*.js --bundle --minify --outdir=bin/api_js/util --platform=node && esbuild module/*.js --bundle --minify --outdir=bin/api_js/module --platform=node"


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [*] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建/工具 (chore)
- [ ] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
修复ARM64架构下Linux版本编译失败问题
---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么: API上游没加ARM64架构的Linux编译选项
- 如何修复的: 在packages.json里加入即可

---

## ✅ 测试验证 How did you test?

- [*] 本地测试通过 Passed local tests
- [*] 关键功能测试 Tested critical features
- [*] 其他测试描述 (如自动化测试、手动测试等): 玲珑版已上传至商店进行公测

---
