### PR TITLE
feat(player): 添加当前播放歌曲视觉标识

### DIFF
--- a/src/components/PlayerControl.vue
+++ b/src/components/PlayerControl.vue
@@ -1042,6 +1042,7 @@ onUnmounted(() => {
 
 // 对外暴露接口
 defineExpose({
+    playing,
     addSongToQueue: async (hash, name, img, author) => {
         clearAutoSwitchTimer();
 

--- a/src/views/PlaylistDetail.vue
+++ b/src/views/PlaylistDetail.vue
@@ -127,7 +127,12 @@
                         <div class="track-checkbox" v-if="batchSelectionMode">
                             <input type="checkbox" :checked="selectedTracks.includes(index)" @click.stop="selectTrack(index, $event)">
                         </div>
-                        <div class="track-number" v-else>{{ index + 1 }}</div>
+                        <div class="track-number" v-else :class="{ 'current': isCurrentSong(item.hash) }">
+                            <div v-if="isCurrentPlaying(item.hash)" class="sound-wave">
+                                <span></span><span></span><span></span>
+                            </div>
+                            <span v-else>{{ index + 1 }}</span>
+                        </div>
 
                         <!-- 网格模式封面 -->
                         <div class="track-cover" v-if="viewMode === 'grid'">
@@ -139,7 +144,7 @@
 
                         <!-- 歌曲信息 -->
                         <div class="track-title-container">
-                            <div class="track-title" :title="item.name">{{ item.name }}
+                            <div class="track-title" :title="item.name" :class="{ 'current': isCurrentSong(item.hash) }">{{ item.name }}
                                 <span v-if="item.privilege == 10" class="icon vip-icon">VIP</span>
                                 <span v-if="item.isHQ" class="icon sq-icon">HQ</span>
                                 <span v-else-if="item.isSQ" class="icon sq-icon">SQ</span>
@@ -1078,6 +1083,16 @@ const changeArtistSort = (sortType) => {
         fetchArtistSongs();
     }
 };
+
+// 判断是否为当前歌曲（不管是否正在播放）
+const isCurrentSong = (hash) => {
+    return props.playerControl?.currentSong?.hash === hash;
+};
+
+// 判断是否为当前正在播放的歌曲
+const isCurrentPlaying = (hash) => {
+    return isCurrentSong(hash) && props.playerControl?.playing;
+};
 </script>
 
 <style scoped>
@@ -1435,6 +1450,56 @@ const changeArtistSort = (sortType) => {
     font-weight: bold;
     margin-right: 10px;
     width: 30px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    height: 20px;
+}
+
+.track-number.current {
+    color: var(--primary-color);
+}
+
+.track-title.current {
+    color: var(--primary-color);
+}
+
+/* 声波动画 */
+.sound-wave {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 16px;
+}
+
+.sound-wave span {
+    width: 3px;
+    background-color: var(--primary-color);
+    animation: wave 0.8s ease-in-out infinite;
+}
+
+.sound-wave span:nth-child(1) {
+    height: 6px;
+    animation-delay: 0s;
+}
+
+.sound-wave span:nth-child(2) {
+    height: 12px;
+    animation-delay: 0.2s;
+}
+
+.sound-wave span:nth-child(3) {
+    height: 8px;
+    animation-delay: 0.4s;
+}
+
+@keyframes wave {
+    0%, 100% {
+        transform: scaleY(0.5);
+    }
+    50% {
+        transform: scaleY(1);
+    }
 }
 
 .track-title-container {


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [ ] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [X] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建/工具 (chore)
- [ ] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> Describe your changes here.




参考 spotify 效果
<img width="2835" height="1481" alt="image" src="https://github.com/user-attachments/assets/1211f5de-044b-4387-8f40-39e48ce31914" />

添加当前播放歌曲视觉标识

- 在播放列表中高亮显示当前歌曲
- 为正在播放的歌曲添加声波动画效果
- 暴露播放状态到组件接口
- 实现当前歌曲判断逻辑
- 更新样式以支持动画和高亮显示
---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么？What was the problem?
- 如何修复的？How was it fixed?

---

## ✅ 测试验证 How did you test?

- [X] 本地测试通过 Passed local tests
- [ ] 关键功能测试 Tested critical features
- [ ] 其他测试描述 (如自动化测试、手动测试等)：
> Please describe testing details

---

## 📚 相关 Issues / Related Issues

> Closes #xxx 或 Related to #xxx

---

## 📷 截图 / Screenshots (如果适用)

<img width="2337" height="1005" alt="image" src="https://github.com/user-attachments/assets/a5e55a45-877f-4cef-908c-89d6c28881a6" />


> 如果有界面变动，附上截图或录屏
