### PR TITLE
fix: add vipType parameter to song URL request

### DIFF
--- a/api/module/song_url.js
+++ b/api/module/song_url.js
@@ -32,6 +32,7 @@ module.exports = (params, useAxios) => {
     cdnBackup: 1,
     kcard: 0,
     module: '',
+    vipType: params?.cookie?.vip_type || params?.vip_type || 0,
   };
 
   return useAxios({

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -19,11 +19,14 @@ httpClient.interceptors.request.use(
         const token = MoeAuth.UserInfo?.token;
         const userid = MoeAuth.UserInfo?.userid;
         const dfid = MoeAuth.UserInfo?.dfid;
+        const vip_type = MoeAuth.UserInfo?.vip_type;
 
         const authParts = [];
         if (token) authParts.push(`token=${encodeURIComponent(token)}`);
         if (userid) authParts.push(`userid=${encodeURIComponent(userid)}`);
         if (dfid) authParts.push(`dfid=${encodeURIComponent(dfid)}`);
+        // vip_type=0 is valid for non-VIP users, so check for undefined explicitly
+        if (vip_type !== undefined) authParts.push(`vip_type=${encodeURIComponent(vip_type)}`);
 
         if (authParts.length > 0) {
             config.headers = {


### PR DESCRIPTION
 ✨ 变更类型 Type of Change

  - Bug 修复 (fix)
  - 新功能 (feat)
  - 文档更新 (docs)
  - 样式调整 (style)
  - 重构 (refactor)
  - 测试相关 (test)
  - 构建/工具 (chore)
  - 其他 (other):

  ---
  📋 变更描述 Description

  - Add vipType to song_url.js params to fix error 20028 "Empty vipType"
  - Pass vip_type in Authorization header from frontend

  This fixes the "本次请求需要验证" (request needs verification) error when fetching song URLs from Kugou API.

  ---
  🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

  - 问题是什么？What was the problem?
    - Kugou API returns error 20028 "本次请求需要验证" (Empty vipType) when requesting song URLs because vipType parameter was missing from the request.
  - 如何修复的？How was it fixed?
    - Added vipType parameter to song_url.js request params
    - Added vip_type to Authorization header in frontend request interceptor

  ---
  ✅ 测试验证 How did you test?

  - 本地测试通过 Passed local tests
  - 关键功能测试 Tested critical features
  - Tested with VIP account - music playback works

  ---
  📚 相关 Issues / Related Issues

  Related to #796 #797 #798

  ---
  📷 截图 / Screenshots (如果适用)

  N/A