### PR TITLE
fix(settings): let meta key and numpad keys can be set to shortcut

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -156,7 +156,7 @@
                         <span>{{ config.label }}</span>
                         <div class="shortcut-input" @click="startRecording(key)"
                             :class="{ 'recording': recordingKey === key }">
-                            {{ shortcuts[key] || $t('dian-ji-she-zhi-kuai-jie-jian') }}
+                            {{ displayShortcut(key) || $t('dian-ji-she-zhi-kuai-jie-jian') }}
                             <div v-if="shortcuts[key]" class="clear-shortcut" @click.stop="clearShortcut(key)">
                                 ×
                             </div>
@@ -1234,6 +1234,33 @@ const closeShortcutSettings = () => {
     recordingKey.value = '';
 };
 
+const displayShortcut = (key) => {
+    if (!shortcuts.value?.[key]) return false;
+    const numkeys = {
+        'num0': 'Num0',
+        'num1': 'Num1',
+        'num2': 'Num2',
+        'num3': 'Num3',
+        'num4': 'Num4',
+        'num5': 'Num5',
+        'num6': 'Num6',
+        'num7': 'Num7',
+        'num8': 'Num8',
+        'num9': 'Num9',
+        'numdec': 'Num.',
+        'numadd': 'Num+',
+        'numsub': 'Num-',
+        'nummult': 'Num*',
+        'numdiv': 'Num/',
+    };
+    const raw = shortcuts.value[key];
+    let display = raw.replace('Meta', '⌘');
+    Object.keys(numkeys).forEach(k => {
+        display = display.replace(k, numkeys[k]);
+    });
+    return display;
+};
+
 const startRecording = (key) => {
     recordingKey.value = key;
     shortcuts.value[key] = t('qing-an-xia-xiu-shi-jian');
@@ -1247,7 +1274,7 @@ const recordShortcut = (e) => {
     const keys = [];
 
     // 修饰键
-    if (e.metaKey) keys.push('CommandOrControl');
+    if (e.metaKey) keys.push('Meta');
     if (e.ctrlKey) keys.push('Ctrl');
     if (e.altKey) keys.push('Alt');
     if (e.shiftKey) keys.push('Shift');
@@ -1260,7 +1287,7 @@ const recordShortcut = (e) => {
 
     // 特殊键映射
     const specialKeys = {
-        ' ': 'Space',
+        'Space': 'Space',
         'ArrowUp': 'Up',
         'ArrowDown': 'Down',
         'ArrowLeft': 'Left',
@@ -1274,16 +1301,26 @@ const recordShortcut = (e) => {
         'PageDown': 'PageDown',
         'Home': 'Home',
         'End': 'End',
-        '+': 'numadd',
-        '-': 'numsub',
-        '*': 'nummult',
-        '/': 'numdiv',
-        '=': 'Equal',
-        '.': 'Dot',
-        'NumpadDecimal': 'numdec'
+
+        // Numpad
+        'Numpad0': 'num0',
+        'Numpad1': 'num1',
+        'Numpad2': 'num2',
+        'Numpad3': 'num3',
+        'Numpad4': 'num4',
+        'Numpad5': 'num5',
+        'Numpad6': 'num6',
+        'Numpad7': 'num7',
+        'Numpad8': 'num8',
+        'Numpad9': 'num9',
+        'NumpadDecimal': 'numdec',
+        'NumpadAdd': 'numadd',
+        'NumpadSubtract': 'numsub',
+        'NumpadMultiply': 'nummult',
+        'NumpadDivide': 'numdiv',
     };
 
-    const key = specialKeys[e.key] || e.key.toUpperCase();
+    const key = specialKeys[e.code] || e.key.toUpperCase();
 
     // 只有当按下的不是单独的修饰键时才结束记录
     if (!['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)) {
@@ -1291,7 +1328,7 @@ const recordShortcut = (e) => {
 
         if (keys.length > 0) {
             // 检查是否包含必要的修饰键
-            if (!keys.some(k => ['Ctrl', 'Alt', 'Shift', 'CommandOrControl'].includes(k))) {
+            if (!keys.some(k => ['Ctrl', 'Alt', 'Shift', 'Meta'].includes(k))) {
                 window.$modal.alert(t('kuai-jie-jian-bi-xu-bao-han-zhi-shao-yi-ge-xiu-shi-jian-ctrlaltshiftcommand'));
                 return;
             }
@@ -1317,7 +1354,7 @@ const recordShortcut = (e) => {
 // 添加快捷键验证函数
 const validateShortcut = (shortcut) => {
     const keys = shortcut.split('+');
-    return keys.some(k => ['Ctrl', 'Alt', 'Shift', 'Command'].includes(k));
+    return keys.some(k => ['Ctrl', 'Alt', 'Shift', 'Meta'].includes(k));
 };
 
 // 修改 saveShortcuts 函数，添加检查
@@ -1469,7 +1506,7 @@ $shadow-medium: rgba(0, 0, 0, 0.18);
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: 16px;
 
-    .setting-card-header i{
+    .setting-card-header i {
         color: var(--primary-color);
     }
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -156,7 +156,8 @@
                         <span>{{ config.label }}</span>
                         <div class="shortcut-input" @click="startRecording(key)"
                             :class="{ 'recording': recordingKey === key }">
-                            {{ displayShortcut(key) || $t('dian-ji-she-zhi-kuai-jie-jian') }}
+                            <!-- {{ displayShortcut(key) || $t('dian-ji-she-zhi-kuai-jie-jian') }} -->
+                            <span v-html="displayShortcut(key) || $t('dian-ji-she-zhi-kuai-jie-jian')" />
                             <div v-if="shortcuts[key]" class="clear-shortcut" @click.stop="clearShortcut(key)">
                                 ×
                             </div>
@@ -1236,7 +1237,10 @@ const closeShortcutSettings = () => {
 
 const displayShortcut = (key) => {
     if (!shortcuts.value?.[key]) return false;
-    const numkeys = {
+    const keys = {
+        'Meta': isElectron() ?
+            window?.electron.platform === 'darwin' ? '⌘' : '<i class="fab fa-windows"></i>' :
+            '⌘/<i class="fab fa-windows"></i>',
         'num0': 'Num0',
         'num1': 'Num1',
         'num2': 'Num2',
@@ -1253,10 +1257,9 @@ const displayShortcut = (key) => {
         'nummult': 'Num*',
         'numdiv': 'Num/',
     };
-    const raw = shortcuts.value[key];
-    let display = raw.replace('Meta', '⌘');
-    Object.keys(numkeys).forEach(k => {
-        display = display.replace(k, numkeys[k]);
+    let display = shortcuts.value[key];
+    Object.keys(keys).forEach(k => {
+        display = display.replace(k, keys[k]);
     });
     return display;
 };


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [x] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建/工具 (chore)
- [ ] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> fix #935 

---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么？What was the problem?
  小键盘数字键和 win 键无法设为快捷键 ( #935 )
- 如何修复的？How was it fixed?
  meta 键从 `CommandOrControl` 修改为 `Meta` [^1]
   - mac 平台： <kbd>⌘ Command</kbd>
   - win/linux 平台： <kbd>⊞ Windows</kbd>
     
  添加小数字键转义到特殊键映射表 [^1]

---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [x] 关键功能测试 Tested critical features
- [x] 其他测试描述 (如自动化测试、手动测试等)：
> windows 开发/生产环境测试正常 其他环境暂未测试
> 构建产物见 https://github.com/LateDreamXD/MoeKoeMusic/releases/tag/v1.6.1

---

## 📚 相关 Issues / Related Issues

> Closes #935 

---

## 📷 截图 / Screenshots (如果适用)

> <img width="203" height="119" alt="image" src="https://github.com/user-attachments/assets/5d821307-ad59-4517-b835-64266ff580be" />

[^1]: 详细信息见 [键盘快捷键 | Electron](https://www.electronjs.org/zh/docs/latest/tutorial/keyboard-shortcuts)