### PR TITLE
feat(electron): allow user disable title update

### DIFF
--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -64,11 +64,24 @@ export function createWindow() {
             sandbox: false,
             webSecurity: false, // 禁用 CORS、同源策略
             allowRunningInsecureContent: true, // 允许混合内容
-            zoomFactor: 1.0
+            zoomFactor: 1.0,
         },
         icon: getIconPath('icon.ico')
     });
     bindExternalLinkHandler(mainWindow);
+
+    const defaultTitle = 'MoeKoe 萌音';
+    mainWindow.setTitle(defaultTitle);
+    mainWindow.on('page-title-updated', (ev, title, explicitSet) => {
+        if (savedConfig?.disableTitleUpdate === 'on') {
+            // ev.preventDefault(); // electron 39 好像有 bug, 这玩意阻止不了标题更新
+            setImmediate(() => {
+                if (mainWindow.getTitle() !== defaultTitle) {
+                    mainWindow.setTitle(defaultTitle);
+                }
+            });
+        }
+    });
 
     if (store.get('maximize')) {
         mainWindow.maximize();

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -225,6 +225,7 @@ const selectedSettings = ref({
     loudnessNormalization: { displayText: t('guan-bi'), value: 'off' },
     pauseOnAudioOutputChange: { displayText: t('guan-bi'), value: 'off' },
     audioOutputDevice: { displayText: '默认', value: 'default' },
+    disableTitleUpdate: { displayText: t('guan-bi'), value: 'off' },
 });
 
 // 设置分区配置
@@ -428,6 +429,12 @@ const settingSections = computed(() => [
                 helpLink: 'https://music.moekoe.cn/guide/proxy-settings.html'
             },
             {
+                key: 'disableTitleUpdate',
+                label: '禁止标题更新',
+                showRefreshHint: true,
+                refreshHintText: t('zhong-qi-hou-sheng-xiao')
+            },
+            {
                 key: 'log',
                 label: '日志',
                 customText: '操作'
@@ -481,6 +488,7 @@ const getItemIcon = (key) => {
         'pwa': 'fas fa-mobile-alt',
         'proxy': 'fas fa-random',
         'startupPage': 'fas fa-home',
+        'disableTitleUpdate': 'fas fa-arrow-rotate-right',
         log: 'fas fa-file-lines'
     };
     return iconMap[key] || 'fas fa-sliders-h';
@@ -731,6 +739,13 @@ const selectionTypeMap = {
         title: '音频输出设备(实验性)',
         options: []
     },
+    disableTitleUpdate: {
+        title: '禁止标题更新',
+        options: [
+            { displayText: t('da-kai'), value: 'on' },
+            { displayText: t('guan-bi'), value: 'off' }
+        ]
+    },
     log: {
         title: '日志',
         options: [
@@ -856,7 +871,7 @@ const openHelpLink = () => {
 };
 
 const selectOption = async (option) => {
-    const electronFeatures = ['desktopLyrics', 'statusBarLyrics', 'gpuAcceleration', 'minimizeToTray', 'highDpi', 'nativeTitleBar', 'touchBar', 'autoStart', 'startMinimized', 'preventAppSuspension', 'networkMode', 'poxySettings', 'apiMode', 'dataSource', 'statusBarLyrics', 'log'];
+    const electronFeatures = ['desktopLyrics', 'statusBarLyrics', 'gpuAcceleration', 'minimizeToTray', 'highDpi', 'nativeTitleBar', 'touchBar', 'autoStart', 'startMinimized', 'preventAppSuspension', 'networkMode', 'poxySettings', 'apiMode', 'dataSource', 'statusBarLyrics', 'disableTitleUpdate', 'log'];
     if (!isElectron() && electronFeatures.includes(selectionType.value)) {
         window.$modal.alert(t('fei-ke-hu-duan-huan-jing-wu-fa-qi-yong'));
         return;
@@ -950,7 +965,7 @@ const selectOption = async (option) => {
     await actions[selectionType.value]?.();
     saveSettings();
     if (!['apiMode', 'font', 'fontUrl', 'proxy', 'apiBaseUrlMode'].includes(selectionType.value)) closeSelection();
-    const refreshHintTypes = ['nativeTitleBar', 'lyricsBackground', 'lyricsFontSize', 'gpuAcceleration', 'highDpi', 'apiMode', 'apiBaseUrlMode', 'touchBar', 'preventAppSuspension', 'networkMode', 'font', 'proxy', 'dataSource', 'loudnessNormalization', 'statusBarLyrics'];
+    const refreshHintTypes = ['nativeTitleBar', 'lyricsBackground', 'lyricsFontSize', 'gpuAcceleration', 'highDpi', 'apiMode', 'apiBaseUrlMode', 'touchBar', 'preventAppSuspension', 'networkMode', 'font', 'proxy', 'dataSource', 'loudnessNormalization', 'statusBarLyrics', 'disableTitleUpdate'];
     if (refreshHintTypes.includes(selectionType.value)) {
         showRefreshHint.value[selectionType.value] = true;
     }


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [ ] Bug 修复 (fix)
- [x] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建/工具 (chore)
- [ ] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> 允许用户禁止主窗口标题更新

---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [x] 关键功能测试 Tested critical features
- [x] 其他测试描述 (如自动化测试、手动测试等)：
> win 开发环境正常 生产环境还未测试

---

## 📚 相关 Issues / Related Issues

> Closes #959

## 📷 截图 / Screenshots (如果适用)

> <img width="300" height="120" alt="image" src="https://github.com/user-attachments/assets/872abd09-b52d-4333-ae97-5fa77b754c41" />

---

## 一些或许没那么重要的
  一开始打算直接监听主窗口`page-title-updated`事件然后直接`preventDefault`
  但是虽然能触发监听器 标题仍然更新了 推测可能是 electron 39 的 bug
  于是改用`setImmediate`判断标题是否更新 若更新则改回默认标题
